### PR TITLE
badge: make text more dynamic and center it in flipped mode.

### DIFF
--- a/firmware/apps/badge/__init__.py
+++ b/firmware/apps/badge/__init__.py
@@ -167,11 +167,13 @@ def update():
             screen.font = small_font
             center_text(id_role, photo_y + 12)
         else:
-            screen.font = large_font
             for account in id_socials.items():
+                screen.font = large_font
                 screen.pen = color.rgb(100, 100, 100)
                 screen.shape(shape.rounded_rectangle(20, socials_y, 17, 17, 3))
                 screen.blit(account[1]["icon"], vec2(20, socials_y))
+                if 15 <= len (account[1]["handle"]):
+                    screen.font = small_font
                 shadow_text(account[1]["handle"], 40, socials_y)
                 socials_y += 21
 

--- a/firmware/apps/badge/__init__.py
+++ b/firmware/apps/badge/__init__.py
@@ -169,12 +169,14 @@ def update():
         else:
             for account in id_socials.items():
                 screen.font = large_font
+                y_offset = 1
                 screen.pen = color.rgb(100, 100, 100)
                 screen.shape(shape.rounded_rectangle(20, socials_y, 17, 17, 3))
                 screen.blit(account[1]["icon"], vec2(20, socials_y))
                 if 15 <= len (account[1]["handle"]):
                     screen.font = small_font
-                shadow_text(account[1]["handle"], 40, socials_y)
+                    y_offset = 2
+                shadow_text(account[1]["handle"], 40, socials_y + y_offset)
                 socials_y += 21
 
 


### PR DESCRIPTION
Previously, the large font was used unconditionally in flipped mode.

Make this dynamic with a cut-off of 15 characters for the large font and use the small font for longer text.

This will not magically fix any overflowing text issue, but gives quite a bit of leeway for most cases/user names.

Additionally, the text was not really centered. Add an y offset for the text only and apply different offsets based on the text font size.

As always, please backport this to the other modules.