### PR TITLE
qwstpad: Improvements and badge monkeypatching.

### DIFF
--- a/modules/common/qwstpad.py
+++ b/modules/common/qwstpad.py
@@ -1,4 +1,5 @@
 import struct
+from collections import OrderedDict
 
 from micropython import const
 from machine import I2C
@@ -39,9 +40,9 @@ class QwSTPad:
     BUTTON_MINUS = 0x5
 
     # Mappings
-    BUTTON_MAPPING = {"A": 0xE, "B": 0xC, "X": 0xF, "Y": 0xD,
+    BUTTON_MAPPING = OrderedDict({"A": 0xE, "B": 0xC, "X": 0xF, "Y": 0xD,
                       "U": 0x1, "D": 0x4, "L": 0x2, "R": 0x3,
-                      "+": 0xB, "-": 0x5}
+                      "+": 0xB, "-": 0x5})
     LED_MAPPING = (0x6, 0x7, 0x9, 0xA)
 
     def __init__(self, i2c=None, address=DEFAULT_ADDRESS, show_address=True):
@@ -60,11 +61,15 @@ class QwSTPad:
         if show_address:
             self.set_leds(self.address_code())
 
+        self.__button_states = OrderedDict({})
+        for key, _ in self.BUTTON_MAPPING.items():
+            self.__button_states[key] = False
+
         self.__button_mask = 0
         for _, value in QwSTPad.BUTTON_MAPPING.items():
             self.__button_mask |= 1 << value
 
-        self.buttons = self.read_buttons()
+        self.buttons = 0
         self.__pressed = 0
         self.__released = 0
         self.__changed = 0
@@ -75,7 +80,8 @@ class QwSTPad:
         return self.__change_bit(0x0000, ADDRESSES.index(self.__address), True)
 
     def read_buttons(self):
-        return self.__reg_read_uint16(self.__i2c, self.__address, self.INPUT_PORT0) & self.__button_mask
+        self.update_buttons()
+        return self.__button_states
 
     def set_leds(self, states):
         self.__led_states = states & 0b1111
@@ -115,12 +121,15 @@ class QwSTPad:
     def update_buttons(self):
         old_values = self.buttons
 
-        self.buttons = self.read_buttons()
+        self.buttons = self.__reg_read_uint16(self.__i2c, self.__address, self.INPUT_PORT0) & self.__button_mask
 
         self.__changed = ~(old_values & self.buttons)
         self.__pressed = self.buttons & self.__changed
         self.__released = ~self.buttons & self.__changed
         self.__held = self.buttons
+
+        for key, value in self.BUTTON_MAPPING.items():
+            self.__button_states[key] = bool(self.__held & (1 << value))
 
     def pressed(self, button=None):
         if button is None:

--- a/modules/common/qwstpad.py
+++ b/modules/common/qwstpad.py
@@ -1,7 +1,7 @@
 import struct
-from collections import OrderedDict
 
 from micropython import const
+from machine import I2C
 
 __version__ = "0.0.1"
 
@@ -27,18 +27,28 @@ class QwSTPad:
     CONFIGURATION_PORT0 = const(0x06)
     CONFIGURATION_PORT1 = const(0x07)
 
+    BUTTON_A = 0xE
+    BUTTON_B = 0xC
+    BUTTON_X = 0xF
+    BUTTON_Y = 0xD
+    BUTTON_UP = 0x1
+    BUTTON_DOWN = 0x4
+    BUTTON_LEFT = 0x2
+    BUTTON_RIGHT = 0x3
+    BUTTON_PLUS = 0xB
+    BUTTON_MINUS = 0x5
+
     # Mappings
-    BUTTON_MAPPING = OrderedDict({"A": 0xE, "B": 0xC, "X": 0xF, "Y": 0xD,
-                                  "U": 0x1, "D": 0x4, "L": 0x2, "R": 0x3,
-                                  "+": 0xB, "-": 0x5
-                                  })
+    BUTTON_MAPPING = {"A": 0xE, "B": 0xC, "X": 0xF, "Y": 0xD,
+                      "U": 0x1, "D": 0x4, "L": 0x2, "R": 0x3,
+                      "+": 0xB, "-": 0x5}
     LED_MAPPING = (0x6, 0x7, 0x9, 0xA)
 
-    def __init__(self, i2c, address=DEFAULT_ADDRESS, show_address=True):
+    def __init__(self, i2c=None, address=DEFAULT_ADDRESS, show_address=True):
         if address not in ADDRESSES:
             raise ValueError("address is not valid. Expected: 0x21, 0x23, 0x25, or 0x27")
 
-        self.__i2c = i2c
+        self.__i2c = i2c or I2C()
         self.__address = address
 
         # Set up the TCA9555 with the correct input and output pins
@@ -46,22 +56,26 @@ class QwSTPad:
         self.__reg_write_uint16(self.__i2c, self.__address, self.POLARITY_PORT0, 0b11111000_00111111)
         self.__reg_write_uint16(self.__i2c, self.__address, self.OUTPUT_PORT0, 0b00000110_11000000)
 
-        self.__button_states = OrderedDict({})
-        for key, _ in self.BUTTON_MAPPING.items():
-            self.__button_states[key] = False
-
         self.__led_states = 0b0000
         if show_address:
             self.set_leds(self.address_code())
+
+        self.__button_mask = 0
+        for _, value in QwSTPad.BUTTON_MAPPING.items():
+            self.__button_mask |= 1 << value
+
+        self.buttons = self.read_buttons()
+        self.__pressed = 0
+        self.__released = 0
+        self.__changed = 0
+        self.__held = 0
+        self.update_buttons()
 
     def address_code(self):
         return self.__change_bit(0x0000, ADDRESSES.index(self.__address), True)
 
     def read_buttons(self):
-        state = self.__reg_read_uint16(self.__i2c, self.__address, self.INPUT_PORT0)
-        for key, value in self.BUTTON_MAPPING.items():
-            self.__button_states[key] = self.__get_bit(state, value)
-        return self.__button_states
+        return self.__reg_read_uint16(self.__i2c, self.__address, self.INPUT_PORT0) & self.__button_mask
 
     def set_leds(self, states):
         self.__led_states = states & 0b1111
@@ -97,3 +111,99 @@ class QwSTPad:
     def __reg_read_uint16(self, i2c, address, reg):
         buffer = i2c.readfrom_mem(address, reg, 2)
         return struct.unpack("<H", buffer)[0]
+
+    def update_buttons(self):
+        old_values = self.buttons
+
+        self.buttons = self.read_buttons()
+
+        self.__changed = ~(old_values & self.buttons)
+        self.__pressed = self.buttons & self.__changed
+        self.__released = ~self.buttons & self.__changed
+        self.__held = self.buttons
+
+    def pressed(self, button=None):
+        if button is None:
+            return self.__pressed > 0
+        return self.__pressed & (1 << QwSTPad.BUTTON_MAPPING[button])
+
+    def released(self, button=None):
+        if button is None:
+            return self.__released > 0
+        return self.__released & (1 << QwSTPad.BUTTON_MAPPING[button])
+
+    def changed(self, button=None):
+        if button is None:
+            return self.__changed > 0
+        return self.__changed & (1 << QwSTPad.BUTTON_MAPPING[button])
+
+    def held(self, button=None):
+        if button is None:
+            return self.__held > 0
+        return self.__held & (1 << QwSTPad.BUTTON_MAPPING[button])
+
+
+class Gamepadhelper:
+    def __init__(self, i2c=None):
+        self.pads = []
+        self.pads_count = 0
+        self.__i2c = i2c
+        self.get_gamepads()
+
+    def get_gamepads(self):
+        pads_count = 0
+
+        # Create a player for each connected QwSTPad
+        for i, addr in enumerate(ADDRESSES):
+            try:
+                self.pads.append(QwSTPad(self.__i2c, addr))
+                print(f"P{i + 1}: Connected")
+                pads_count += 1
+            except OSError:
+                self.pads.append(None)
+                print(f"P{i + 1}: Not Connected")
+
+        self.pads_count = pads_count
+
+    def monkeypatch(self, gamepad):
+        self.get_gamepads()
+        _pad = self.pads[gamepad]
+        if _pad is None:
+            raise RuntimeError(f"Gamepad {gamepad} is not connected!")
+
+        def _remap(button):
+            return {
+                BUTTON_A: "L",
+                BUTTON_B: "B",
+                BUTTON_C: "R",
+                BUTTON_UP: "U",
+                BUTTON_DOWN: "D",
+            }[button]
+
+        _badge_pressed = badge.pressed
+        _badge_held = badge.held
+        _badge_released = badge.released
+        _badge_changed = badge.changed
+        _badge_poll = badge.poll
+
+        def _pressed(button=None):
+            return _badge_pressed(button) or _pad.pressed(_remap(button))
+
+        def _held(button=None):
+            return _badge_held(button) or _pad.held(_remap(button))
+
+        def _released(button=None):
+            return _badge_released(button) or _pad.released(_remap(button))
+
+        def _changed(button=None):
+            return _badge_changed(button) or _pad.changed(_remap(button))
+
+        def _poll():
+            _badge_poll()
+            _pad.update_buttons()
+
+        badge.pressed = _pressed
+        badge.held = _held
+        badge.released = _released
+        badge.changed = _changed
+        badge.poll = _poll


### PR DESCRIPTION
* Use board default I2C pins.
* Refactor button states to use ints/bits for smaller memory footprint.
* Add a monkeypatch feature to  Gamepadhelper for an easy augmentation of builtin badgeware controls.

Assuming a controller is connected, use with:

```python
import qwstpad
qwstpad.Gamepadhelper().monkeypatch(0)
```