### PR TITLE
apps/demos: Filter dotfiles from demo list.

### DIFF
--- a/firmware/apps/demos/demos/__init__.py
+++ b/firmware/apps/demos/demos/__init__.py
@@ -4,7 +4,7 @@ import sys
 demos = {}
 for file in os.listdir(__path__):
   file = file.rsplit(".", 1)[0]
-  if not file.startswith("__"):
+  if not file.startswith(("__", ".")):
     demos[file] = __path__ + "/" + file
 
 sys.modules[__name__].demos = demos


### PR DESCRIPTION
An editor, eg: vscode, could leave a ._filename.py file in the demos directory when editing over USB mass storage- breaking the demos app with a cryptic error:

ImportError: no module named "/system/apps/demos/demos/"