### PR TITLE
Allow app title/icon color to be changed thru a new appmanifest.json file

### DIFF
--- a/firmware/apps/menu/app.py
+++ b/firmware/apps/menu/app.py
@@ -1,7 +1,6 @@
 import os
 import math
 import json
-from modules.common.badgeware.filesystem import file_exists, is_dir
 import ui
 
 orange = color.rgb(246, 135, 4)
@@ -122,16 +121,16 @@ class Apps:
             custom_color=None
             custom_fade_color=None
             if file_exists(f"{root}/{path}/appmanifest.json"):
-                    try:
-                        with open(f"{root}/{path}/appmanifest.json") as f:
-                            data=json.load(f)
-                            name=data.get("title", None)
-                            normal_color=data.get("color",None) # Should be a 4 integer list being passed into normal_color
-                            fade_color=data.get("fade_color",None) # Should be a 4 integer list being passed into fade_color
-                            custom_color=tuple(normal_color) if normal_color else None
-                            custom_fade_color=tuple(fade_color) if fade_color else None
-                    except Exception:
-                            pass
+                try:
+                    with open(f"{root}/{path}/appmanifest.json") as f:
+                        data=json.load(f)
+                        name=data.get("title", None)
+                        normal_color=data.get("color",None) # Should be a 4 integer list being passed into normal_color
+                        fade_color=data.get("fade_color",None) # Should be a 4 integer list being passed into fade_color
+                        custom_color=tuple(normal_color) if normal_color else None
+                        custom_fade_color=tuple(fade_color) if fade_color else None
+                except Exception:
+                        pass
 
             if name is None:
                 name = " ".join([capitalize(word) for word in path.split("_")])

--- a/firmware/apps/menu/app.py
+++ b/firmware/apps/menu/app.py
@@ -118,6 +118,9 @@ class Apps:
                 return word
             return word[0].upper() + word[1:]
         for path in sorted(os.listdir(root)):
+            name=None
+            custom_color=None
+            custom_fade_color=None
             if file_exists(f"{root}/{path}/appmanifest.json"):
                     try:
                         with open(f"{root}/{path}/appmanifest.json") as f:
@@ -128,14 +131,8 @@ class Apps:
                             custom_color=tuple(normal_color) if normal_color else None
                             custom_fade_color=tuple(fade_color) if fade_color else None
                     except Exception:
-                        name=None
-                        custom_color=None
-                        custom_fade_color=None
+                            pass
 
-            else:
-                name=None
-                custom_color=None
-                custom_fade_color=None
             if name is None:
                 name = " ".join([capitalize(word) for word in path.split("_")])
 

--- a/firmware/apps/menu/app.py
+++ b/firmware/apps/menu/app.py
@@ -117,30 +117,31 @@ class Apps:
             if len(word) <= 1:
                 return word
             return word[0].upper() + word[1:]
-        if is_dir(f"{root}/{path}"):
-                if file_exists(f"{root}/{path}/appmanifest.json"):
-                    with open(f"{root}/{path}/appmanifest.json") as f:
-                        try:
+        for path in sorted(os.listdir(root)):
+            if file_exists(f"{root}/{path}/appmanifest.json"):
+                    try:
+                        with open(f"{root}/{path}/appmanifest.json") as f:
                             data=json.load(f)
-                        except Exception:
-                            data = {}
-                        name=data.get("title", None)
-                        normal_color=data.get("color",None)
-                        fade_color=data.get("fade_color",None)
-                        custom_color=tuple(normal_color) if normal_color else None
-                        custom_fade_color=tuple(fade_color) if fade_color else None
+                            name=data.get("title", None)
+                            normal_color=data.get("color",None) # Should be a 4 integer list being passed into normal_color
+                            fade_color=data.get("fade_color",None) # Should be a 4 integer list being passed into fade_color
+                            custom_color=tuple(normal_color) if normal_color else None
+                            custom_fade_color=tuple(fade_color) if fade_color else None
+                    except Exception:
+                        name=None
+                        custom_color=None
+                        custom_fade_color=None
 
-                else:
-                    name=None
-                    custom_color=None
-                    custom_fade_color=None
-        if name==None:
-            for path in sorted(os.listdir(root)):
+            else:
+                name=None
+                custom_color=None
+                custom_fade_color=None
+            if name is None:
                 name = " ".join([capitalize(word) for word in path.split("_")])
 
-        if is_dir(f"{root}/{path}"):
-            if file_exists(f"{root}/{path}/icon.png"):
-                App(self.apps, name, path, image.load(f"{root}/{path}/icon.png"), custom_color=custom_color, custom_fade_color=custom_fade_color)
+            if is_dir(f"{root}/{path}"):
+                if file_exists(f"{root}/{path}/icon.png"):
+                    App(self.apps, name, path, image.load(f"{root}/{path}/icon.png"), custom_color, custom_fade_color)
 
     @property
     def active(self):

--- a/firmware/apps/menu/app.py
+++ b/firmware/apps/menu/app.py
@@ -32,7 +32,7 @@ shade_brush = color.rgb(0, 0, 0, 50)
 
 
 class App:
-    def __init__(self, collection, name, path, icon):
+    def __init__(self, collection, name, path, icon,custom_color=None|tuple[int,int,int,int],custom_fade_color=None|tuple[int,int,int,int]):
         self.active = False
         self.index = len(collection)
         self.pos = vec2((self.index % 3) * 48 + 32, (math.floor((self.index % 6) / 3)) * 48 + 42)
@@ -40,6 +40,8 @@ class App:
         self.name = name
         self.path = path
         self.spin = False
+        self.custom_color = color.rgb(*custom_color) if custom_color else None
+        self.custom_fade_color = color.rgb(*custom_fade_color) if custom_fade_color else None
         collection.append(self)
 
     def activate(self, active):
@@ -84,9 +86,9 @@ class App:
         # draw the icon body
         squircle.transform = squircle.transform.scale(1, 1)
         if self.active:
-            screen.pen = bold[self.index % 6]
+            screen.pen = bold[self.index % 6] if self.custom_color is None else self.custom_color
         else:
-            screen.pen = faded[self.index % 6]
+            screen.pen = faded[self.index % 6] if self.custom_fade_color is None else self.custom_fade_color
         squircle.transform = squircle.transform.translate(-1, -1)
         screen.shape(squircle)
         squircle.transform = squircle.transform.translate(2, 2)
@@ -119,17 +121,27 @@ class Apps:
         if is_dir(f"{root}/{path}"):
                 if file_exists(f"{root}/{path}/appmanifest.json"):
                     with open(f"{root}/{path}/appmanifest.json") as f:
-                        data=json.load(f)
+                        try:
+                            data=json.load(f)
+                        except Exception:
+                            data = {}
                         name=data.get("title", None)
+                        normal_color=data.get("color",None)
+                        fade_color=data.get("fade_color",None)
+                        custom_color=tuple(normal_color) if normal_color else None
+                        custom_fade_color=tuple(fade_color) if fade_color else None
+
                 else:
                     name=None
+                    custom_color=None
+                    custom_fade_color=None
         if name==None:
             for path in sorted(os.listdir(root)):
                 name = " ".join([capitalize(word) for word in path.split("_")])
 
         if is_dir(f"{root}/{path}"):
             if file_exists(f"{root}/{path}/icon.png"):
-                App(self.apps, name, path, image.load(f"{root}/{path}/icon.png"))
+                App(self.apps, name, path, image.load(f"{root}/{path}/icon.png"), custom_color=custom_color, custom_fade_color=custom_fade_color)
 
     @property
     def active(self):

--- a/firmware/apps/menu/app.py
+++ b/firmware/apps/menu/app.py
@@ -1,6 +1,8 @@
+from logging import root
 import os
 import math
-
+import json
+from modules.common.badgeware.filesystem import file_exists, is_dir
 import ui
 
 orange = color.rgb(246, 135, 4)
@@ -114,13 +116,20 @@ class Apps:
             if len(word) <= 1:
                 return word
             return word[0].upper() + word[1:]
+        if is_dir(f"{root}/{path}"):
+                if file_exists(f"{root}/{path}/appmanifest.json"):
+                    with open(f"{root}/{path}/appmanifest.json") as f:
+                        data=json.load(f)
+                        name=data.get("title", None)
+                else:
+                    name=None
+        if name==None:
+            for path in sorted(os.listdir(root)):
+                name = " ".join([capitalize(word) for word in path.split("_")])
 
-        for path in sorted(os.listdir(root)):
-            name = " ".join([capitalize(word) for word in path.split("_")])
-
-            if is_dir(f"{root}/{path}"):
-                if file_exists(f"{root}/{path}/icon.png"):
-                    App(self.apps, name, path, image.load(f"{root}/{path}/icon.png"))
+        if is_dir(f"{root}/{path}"):
+            if file_exists(f"{root}/{path}/icon.png"):
+                App(self.apps, name, path, image.load(f"{root}/{path}/icon.png"))
 
     @property
     def active(self):

--- a/firmware/apps/menu/app.py
+++ b/firmware/apps/menu/app.py
@@ -1,4 +1,3 @@
-from logging import root
 import os
 import math
 import json


### PR DESCRIPTION
Haven't received my Tufty yet, so I am unable to test, and feel free to mention any problems, but in theory, what this code should do is allow for an option to use an appmanifest.json file in the app's folder to use a title not auto-determined by the code, custom color for app icons, along with faded ones as well. Should any part of the appmanifest.json not exist, the code *should* fall back to defaults (auto-title determination, along with default colors).
I have attached a sample of what an appmanifest.json could look like:
[ex-appmanifest.json](https://github.com/user-attachments/files/26802175/ex-appmanifest.json)

Some of this code could be ported to other badges, but I'm not sure.